### PR TITLE
Provide compatibility with old chat format.

### DIFF
--- a/src/main/java/mkremins/fanciful/FancyMessage.java
+++ b/src/main/java/mkremins/fanciful/FancyMessage.java
@@ -223,6 +223,14 @@ public class FancyMessage {
 		}
 	}
 	
+	public String toOldMessageFormat() {
+		String result = "";
+		for (MessagePart part : messageParts) {
+			result += part.color + part.text;
+		}
+		return result;
+	}
+	
 	private MessagePart latest() {
 		return messageParts.get(messageParts.size() - 1);
 	}


### PR DESCRIPTION
Add a method to convert the FancyMessage into an normal String. This is usefull for sending messages to consol or other readers, who don't support the json chat format.
