### PR TITLE
fix ArbitraryTextTypeComponent to restrict on value being empty

### DIFF
--- a/src/main/java/mkremins/fanciful/TextualComponent.java
+++ b/src/main/java/mkremins/fanciful/TextualComponent.java
@@ -85,7 +85,7 @@ public abstract class TextualComponent implements Cloneable {
 		}
 
 		public void setValue(String value) {
-			Preconditions.checkArgument(value != null && !value.isEmpty(), "The value must be specified.");
+			Preconditions.checkArgument(value != null, "The value must be specified.");
 			_value = value;
 		}
 


### PR DESCRIPTION
in my eyes the restriction on that the value of ArbitraryTextTypeComponent  can't be "" is to strict.
and ComplexTextTypeComponent does not have this restriction.

i have run into this in my plugin when updating the fanciful library. The reason i ran into this is that in order to convert some message into JSON dynamically and not add tons of checks the ability to add empty strings is necessary i hope you will review this change and merge it to the project
