### PR TITLE
Update pom.xml to use Spigot-1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,16 +14,16 @@
 
   <repositories>
     <repository>
-      <id>bukkit-repo</id>
-      <url>http://repo.bukkit.org/content/groups/public/</url>
+      <id>spigotmc</id>
+      <url>https://hub.spigotmc.org/nexus/content/groups/public/</url>
     </repository>
   </repositories>
   
   <dependencies>
     <dependency>
-      <groupId>org.bukkit</groupId>
-      <artifactId>bukkit</artifactId>
-      <version>1.7.9-R0.1</version>
+      <groupId>org.spigotmc</groupId>
+      <artifactId>spigot-api</artifactId>
+      <version>1.8-R0.1-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Update the POM to use Spigot-1.8 rather than bukkit 1.7.9

The 1.8 Spigot API seems to be the better API to use with the recent updates
