### PR TITLE
Allow FancyMessages to be sent in 1.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>mkremins</groupId>
 	<artifactId>fanciful</artifactId>
-	<version>0.3.3-SNAPSHOT</version>
+	<version>0.3.4-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<properties>
@@ -21,7 +21,7 @@
 		<dependency>
 			<groupId>org.bukkit</groupId>
 			<artifactId>bukkit</artifactId>
-			<version>1.8.3-R0.1-SNAPSHOT</version>
+			<version>1.10-R0.1-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/src/main/java/mkremins/fanciful/FancyMessage.java
+++ b/src/main/java/mkremins/fanciful/FancyMessage.java
@@ -641,10 +641,10 @@ public class FancyMessage implements JsonRepresentedObject, Cloneable, Iterable<
 
 			String version = Reflection.getVersion();
 			double majorVersion = Double.parseDouble(version.replace('_', '.').substring(1, 4));
-            int lesserVersion = 0;
-            if (majorVersion == 1.8) {
-                lesserVersion = Integer.parseInt(version.substring(6, 7));
-            }
+			int lesserVersion = 0;
+			if (majorVersion == 1.8) {
+				lesserVersion = Integer.parseInt(version.substring(6, 7));
+			}
 
 			if (majorVersion < 1.8 || (majorVersion == 1.8 && lesserVersion == 1)) {
 				chatSerializerClazz = Reflection.getNMSClass("ChatSerializer");

--- a/src/main/java/mkremins/fanciful/FancyMessage.java
+++ b/src/main/java/mkremins/fanciful/FancyMessage.java
@@ -641,7 +641,10 @@ public class FancyMessage implements JsonRepresentedObject, Cloneable, Iterable<
 
 			String version = Reflection.getVersion();
 			double majorVersion = Double.parseDouble(version.replace('_', '.').substring(1, 4));
-			int lesserVersion = Integer.parseInt(version.substring(6, 7));
+            int lesserVersion = 0;
+            if (majorVersion == 1.8) {
+                lesserVersion = Integer.parseInt(version.substring(6, 7));
+            }
 
 			if (majorVersion < 1.8 || (majorVersion == 1.8 && lesserVersion == 1)) {
 				chatSerializerClazz = Reflection.getNMSClass("ChatSerializer");


### PR DESCRIPTION
With MC 1.10, the version format is slightly different, breaking previous substring calls.

The Pull Request changes the logic slightly so that the substring method to get the minor version is only called if the server is on MC 1.8, as this is the only time the minor version actually matters; higher versions don't use it.