### PR TITLE
Fixed version parsing for Minecraft 1.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Use Maven. Add the Fanciful repository and dependency entries to your `pom.xml`.
 <dependency>
   <groupId>mkremins</groupId>
   <artifactId>fanciful</artifactId>
-  <version>0.3.3-SNAPSHOT</version>
+  <version>0.3.5-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Fanciful [![Build Status](http://ci.stealthyone.com/buildStatus/icon?job=Fanciful)](http://ci.stealthyone.com/job/Fanciful/)
+Fanciful
 ========
 Lightweight library offering pleasant chat message formatting for Bukkit plugins. A way to get at the good stuff offered by Minecraft 1.7's new chat protocol without dropping down to raw JSON.
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>mkremins</groupId>
 	<artifactId>fanciful</artifactId>
-	<version>0.3.4-SNAPSHOT</version>
+	<version>0.3.5-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<properties>

--- a/src/main/java/mkremins/fanciful/FancyMessage.java
+++ b/src/main/java/mkremins/fanciful/FancyMessage.java
@@ -1,21 +1,5 @@
 package mkremins.fanciful;
 
-import java.io.IOException;
-import java.io.StringWriter;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.logging.Level;
-import static mkremins.fanciful.TextualComponent.rawText;
-
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -36,19 +20,36 @@ import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
+import java.io.IOException;
+import java.io.StringWriter;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+
+import static mkremins.fanciful.TextualComponent.rawText;
+
 /**
  * Represents a formattable message. Such messages can use elements such as colors, formatting codes, hover and click data, and other features provided by the vanilla Minecraft <a href="http://minecraft.gamepedia.com/Tellraw#Raw_JSON_Text">JSON message formatter</a>.
  * This class allows plugins to emulate the functionality of the vanilla Minecraft <a href="http://minecraft.gamepedia.com/Commands#tellraw">tellraw command</a>.
  * <p>
  * This class follows the builder pattern, allowing for method chaining.
  * It is set up such that invocations of property-setting methods will affect the current editing component,
- * and a call to {@link #then()} or {@link #then(Object)} will append a new editing component to the end of the message,
+ * and a call to {@link #then()} or {@link #then(String)} will append a new editing component to the end of the message,
  * optionally initializing it with text. Further property-setting method calls will affect that editing component.
  * </p>
  */
 public class FancyMessage implements JsonRepresentedObject, Cloneable, Iterable<MessagePart>, ConfigurationSerializable {
 
-	static{
+	static {
 		ConfigurationSerialization.registerClass(FancyMessage.class);
 	}
 
@@ -58,11 +59,11 @@ public class FancyMessage implements JsonRepresentedObject, Cloneable, Iterable<
 
 	private static Constructor<?> nmsPacketPlayOutChatConstructor;
 
-        @Override
-	public FancyMessage clone() throws CloneNotSupportedException{
-		FancyMessage instance = (FancyMessage)super.clone();
+	@Override
+	public FancyMessage clone() throws CloneNotSupportedException {
+		FancyMessage instance = (FancyMessage) super.clone();
 		instance.messageParts = new ArrayList<MessagePart>(messageParts.size());
-		for(int i = 0; i < messageParts.size(); i++){
+		for (int i = 0; i < messageParts.size(); i++) {
 			instance.messageParts.add(i, messageParts.get(i).clone());
 		}
 		instance.dirty = false;
@@ -72,6 +73,7 @@ public class FancyMessage implements JsonRepresentedObject, Cloneable, Iterable<
 
 	/**
 	 * Creates a JSON message with text.
+	 *
 	 * @param firstPartText The existing text in the message.
 	 */
 	public FancyMessage(final String firstPartText) {
@@ -84,7 +86,7 @@ public class FancyMessage implements JsonRepresentedObject, Cloneable, Iterable<
 		jsonString = null;
 		dirty = false;
 
-		if(nmsPacketPlayOutChatConstructor == null){
+		if (nmsPacketPlayOutChatConstructor == null) {
 			try {
 				nmsPacketPlayOutChatConstructor = Reflection.getNMSClass("PacketPlayOutChat").getDeclaredConstructor(Reflection.getNMSClass("IChatBaseComponent"));
 				nmsPacketPlayOutChatConstructor.setAccessible(true);
@@ -100,11 +102,12 @@ public class FancyMessage implements JsonRepresentedObject, Cloneable, Iterable<
 	 * Creates a JSON message without text.
 	 */
 	public FancyMessage() {
-		this((TextualComponent)null);
+		this((TextualComponent) null);
 	}
 
 	/**
 	 * Sets the text of the current editing component to a value.
+	 *
 	 * @param text The new text of the current editing component.
 	 * @return This builder instance.
 	 */
@@ -117,6 +120,7 @@ public class FancyMessage implements JsonRepresentedObject, Cloneable, Iterable<
 
 	/**
 	 * Sets the text of the current editing component to a value.
+	 *
 	 * @param text The new text of the current editing component.
 	 * @return This builder instance.
 	 */
@@ -129,9 +133,10 @@ public class FancyMessage implements JsonRepresentedObject, Cloneable, Iterable<
 
 	/**
 	 * Sets the color of the current editing component to a value.
+	 *
 	 * @param color The new color of the current editing component.
 	 * @return This builder instance.
-	 * @exception IllegalArgumentException If the specified {@code ChatColor} enumeration value is not a color (but a format value).
+	 * @throws IllegalArgumentException If the specified {@code ChatColor} enumeration value is not a color (but a format value).
 	 */
 	public FancyMessage color(final ChatColor color) {
 		if (!color.isColor()) {
@@ -144,9 +149,10 @@ public class FancyMessage implements JsonRepresentedObject, Cloneable, Iterable<
 
 	/**
 	 * Sets the stylization of the current editing component.
+	 *
 	 * @param styles The array of styles to apply to the editing component.
 	 * @return This builder instance.
-	 * @exception IllegalArgumentException If any of the enumeration values in the array do not represent formatters.
+	 * @throws IllegalArgumentException If any of the enumeration values in the array do not represent formatters.
 	 */
 	public FancyMessage style(ChatColor... styles) {
 		for (final ChatColor style : styles) {
@@ -161,6 +167,7 @@ public class FancyMessage implements JsonRepresentedObject, Cloneable, Iterable<
 
 	/**
 	 * Set the behavior of the current editing component to instruct the client to open a file on the client side filesystem when the currently edited part of the {@code FancyMessage} is clicked.
+	 *
 	 * @param path The path of the file on the client filesystem.
 	 * @return This builder instance.
 	 */
@@ -171,6 +178,7 @@ public class FancyMessage implements JsonRepresentedObject, Cloneable, Iterable<
 
 	/**
 	 * Set the behavior of the current editing component to instruct the client to open a webpage in the client's web browser when the currently edited part of the {@code FancyMessage} is clicked.
+	 *
 	 * @param url The URL of the page to open when the link is clicked.
 	 * @return This builder instance.
 	 */
@@ -182,6 +190,7 @@ public class FancyMessage implements JsonRepresentedObject, Cloneable, Iterable<
 	/**
 	 * Set the behavior of the current editing component to instruct the client to replace the chat input box content with the specified string when the currently edited part of the {@code FancyMessage} is clicked.
 	 * The client will not immediately send the command to the server to be executed unless the client player submits the command/chat message, usually with the enter key.
+	 *
 	 * @param command The text to display in the chat bar of the client.
 	 * @return This builder instance.
 	 */
@@ -189,10 +198,11 @@ public class FancyMessage implements JsonRepresentedObject, Cloneable, Iterable<
 		onClick("suggest_command", command);
 		return this;
 	}
-	
+
 	/**
 	 * Set the behavior of the current editing component to instruct the client to append the chat input box content with the specified string when the currently edited part of the {@code FancyMessage} is SHIFT-CLICKED.
 	 * The client will not immediately send the command to the server to be executed unless the client player submits the command/chat message, usually with the enter key.
+	 *
 	 * @param command The text to append to the chat bar of the client.
 	 * @return This builder instance.
 	 */
@@ -205,6 +215,7 @@ public class FancyMessage implements JsonRepresentedObject, Cloneable, Iterable<
 	/**
 	 * Set the behavior of the current editing component to instruct the client to send the specified string to the server as a chat message when the currently edited part of the {@code FancyMessage} is clicked.
 	 * The client <b>will</b> immediately send the command to the server to be executed when the editing component is clicked.
+	 *
 	 * @param command The text to display in the chat bar of the client.
 	 * @return This builder instance.
 	 */
@@ -216,6 +227,7 @@ public class FancyMessage implements JsonRepresentedObject, Cloneable, Iterable<
 	/**
 	 * Set the behavior of the current editing component to display information about an achievement when the client hovers over the text.
 	 * <p>Tooltips do not inherit display characteristics, such as color and styles, from the message component on which they are applied.</p>
+	 *
 	 * @param name The name of the achievement to display, excluding the "achievement." prefix.
 	 * @return This builder instance.
 	 */
@@ -227,6 +239,7 @@ public class FancyMessage implements JsonRepresentedObject, Cloneable, Iterable<
 	/**
 	 * Set the behavior of the current editing component to display information about an achievement when the client hovers over the text.
 	 * <p>Tooltips do not inherit display characteristics, such as color and styles, from the message component on which they are applied.</p>
+	 *
 	 * @param which The achievement to display.
 	 * @return This builder instance.
 	 */
@@ -235,23 +248,24 @@ public class FancyMessage implements JsonRepresentedObject, Cloneable, Iterable<
 			Object achievement = Reflection.getMethod(Reflection.getOBCClass("CraftStatistic"), "getNMSAchievement", Achievement.class).invoke(null, which);
 			return achievementTooltip((String) Reflection.getField(Reflection.getNMSClass("Achievement"), "name").get(achievement));
 		} catch (IllegalAccessException e) {
-                        Bukkit.getLogger().log(Level.WARNING, "Could not access method.", e);
+			Bukkit.getLogger().log(Level.WARNING, "Could not access method.", e);
 			return this;
 		} catch (IllegalArgumentException e) {
-                        Bukkit.getLogger().log(Level.WARNING, "Argument could not be passed.", e);
-                        return this;
-                } catch (InvocationTargetException e) {
-                        Bukkit.getLogger().log(Level.WARNING, "A error has occured durring invoking of method.", e);
-                        return this;
-                }
+			Bukkit.getLogger().log(Level.WARNING, "Argument could not be passed.", e);
+			return this;
+		} catch (InvocationTargetException e) {
+			Bukkit.getLogger().log(Level.WARNING, "A error has occured durring invoking of method.", e);
+			return this;
+		}
 	}
 
 	/**
 	 * Set the behavior of the current editing component to display information about a parameterless statistic when the client hovers over the text.
 	 * <p>Tooltips do not inherit display characteristics, such as color and styles, from the message component on which they are applied.</p>
+	 *
 	 * @param which The statistic to display.
 	 * @return This builder instance.
-	 * @exception IllegalArgumentException If the statistic requires a parameter which was not supplied.
+	 * @throws IllegalArgumentException If the statistic requires a parameter which was not supplied.
 	 */
 	public FancyMessage statisticTooltip(final Statistic which) {
 		Type type = which.getType();
@@ -262,24 +276,25 @@ public class FancyMessage implements JsonRepresentedObject, Cloneable, Iterable<
 			Object statistic = Reflection.getMethod(Reflection.getOBCClass("CraftStatistic"), "getNMSStatistic", Statistic.class).invoke(null, which);
 			return achievementTooltip((String) Reflection.getField(Reflection.getNMSClass("Statistic"), "name").get(statistic));
 		} catch (IllegalAccessException e) {
-                        Bukkit.getLogger().log(Level.WARNING, "Could not access method.", e);
+			Bukkit.getLogger().log(Level.WARNING, "Could not access method.", e);
 			return this;
 		} catch (IllegalArgumentException e) {
-                        Bukkit.getLogger().log(Level.WARNING, "Argument could not be passed.", e);
-                        return this;
-                } catch (InvocationTargetException e) {
-                        Bukkit.getLogger().log(Level.WARNING, "A error has occured durring invoking of method.", e);
-                        return this;
-                }
+			Bukkit.getLogger().log(Level.WARNING, "Argument could not be passed.", e);
+			return this;
+		} catch (InvocationTargetException e) {
+			Bukkit.getLogger().log(Level.WARNING, "A error has occured durring invoking of method.", e);
+			return this;
+		}
 	}
 
 	/**
 	 * Set the behavior of the current editing component to display information about a statistic parameter with a material when the client hovers over the text.
 	 * <p>Tooltips do not inherit display characteristics, such as color and styles, from the message component on which they are applied.</p>
+	 *
 	 * @param which The statistic to display.
-	 * @param item The sole material parameter to the statistic.
+	 * @param item  The sole material parameter to the statistic.
 	 * @return This builder instance.
-	 * @exception IllegalArgumentException If the statistic requires a parameter which was not supplied, or was supplied a parameter that was not required.
+	 * @throws IllegalArgumentException If the statistic requires a parameter which was not supplied, or was supplied a parameter that was not required.
 	 */
 	public FancyMessage statisticTooltip(final Statistic which, Material item) {
 		Type type = which.getType();
@@ -293,24 +308,25 @@ public class FancyMessage implements JsonRepresentedObject, Cloneable, Iterable<
 			Object statistic = Reflection.getMethod(Reflection.getOBCClass("CraftStatistic"), "getMaterialStatistic", Statistic.class, Material.class).invoke(null, which, item);
 			return achievementTooltip((String) Reflection.getField(Reflection.getNMSClass("Statistic"), "name").get(statistic));
 		} catch (IllegalAccessException e) {
-                        Bukkit.getLogger().log(Level.WARNING, "Could not access method.", e);
+			Bukkit.getLogger().log(Level.WARNING, "Could not access method.", e);
 			return this;
 		} catch (IllegalArgumentException e) {
-                        Bukkit.getLogger().log(Level.WARNING, "Argument could not be passed.", e);
-                        return this;
-                } catch (InvocationTargetException e) {
-                        Bukkit.getLogger().log(Level.WARNING, "A error has occured durring invoking of method.", e);
-                        return this;
-                }
+			Bukkit.getLogger().log(Level.WARNING, "Argument could not be passed.", e);
+			return this;
+		} catch (InvocationTargetException e) {
+			Bukkit.getLogger().log(Level.WARNING, "A error has occured durring invoking of method.", e);
+			return this;
+		}
 	}
 
 	/**
 	 * Set the behavior of the current editing component to display information about a statistic parameter with an entity type when the client hovers over the text.
 	 * <p>Tooltips do not inherit display characteristics, such as color and styles, from the message component on which they are applied.</p>
-	 * @param which The statistic to display.
+	 *
+	 * @param which  The statistic to display.
 	 * @param entity The sole entity type parameter to the statistic.
 	 * @return This builder instance.
-	 * @exception IllegalArgumentException If the statistic requires a parameter which was not supplied, or was supplied a parameter that was not required.
+	 * @throws IllegalArgumentException If the statistic requires a parameter which was not supplied, or was supplied a parameter that was not required.
 	 */
 	public FancyMessage statisticTooltip(final Statistic which, EntityType entity) {
 		Type type = which.getType();
@@ -324,20 +340,21 @@ public class FancyMessage implements JsonRepresentedObject, Cloneable, Iterable<
 			Object statistic = Reflection.getMethod(Reflection.getOBCClass("CraftStatistic"), "getEntityStatistic", Statistic.class, EntityType.class).invoke(null, which, entity);
 			return achievementTooltip((String) Reflection.getField(Reflection.getNMSClass("Statistic"), "name").get(statistic));
 		} catch (IllegalAccessException e) {
-                        Bukkit.getLogger().log(Level.WARNING, "Could not access method.", e);
+			Bukkit.getLogger().log(Level.WARNING, "Could not access method.", e);
 			return this;
 		} catch (IllegalArgumentException e) {
-                        Bukkit.getLogger().log(Level.WARNING, "Argument could not be passed.", e);
-                        return this;
-                } catch (InvocationTargetException e) {
-                        Bukkit.getLogger().log(Level.WARNING, "A error has occured durring invoking of method.", e);
-                        return this;
-                }
+			Bukkit.getLogger().log(Level.WARNING, "Argument could not be passed.", e);
+			return this;
+		} catch (InvocationTargetException e) {
+			Bukkit.getLogger().log(Level.WARNING, "A error has occured durring invoking of method.", e);
+			return this;
+		}
 	}
 
 	/**
 	 * Set the behavior of the current editing component to display information about an item when the client hovers over the text.
 	 * <p>Tooltips do not inherit display characteristics, such as color and styles, from the message component on which they are applied.</p>
+	 *
 	 * @param itemJSON A string representing the JSON-serialized NBT data tag of an {@link ItemStack}.
 	 * @return This builder instance.
 	 */
@@ -349,6 +366,7 @@ public class FancyMessage implements JsonRepresentedObject, Cloneable, Iterable<
 	/**
 	 * Set the behavior of the current editing component to display information about an item when the client hovers over the text.
 	 * <p>Tooltips do not inherit display characteristics, such as color and styles, from the message component on which they are applied.</p>
+	 *
 	 * @param itemStack The stack for which to display information.
 	 * @return This builder instance.
 	 */
@@ -361,11 +379,11 @@ public class FancyMessage implements JsonRepresentedObject, Cloneable, Iterable<
 			return this;
 		}
 	}
-	
 
 	/**
 	 * Set the behavior of the current editing component to display raw text when the client hovers over the text.
 	 * <p>Tooltips do not inherit display characteristics, such as color and styles, from the message component on which they are applied.</p>
+	 *
 	 * @param text The text, which supports newlines, which will be displayed to the client upon hovering.
 	 * @return This builder instance.
 	 */
@@ -377,6 +395,7 @@ public class FancyMessage implements JsonRepresentedObject, Cloneable, Iterable<
 	/**
 	 * Set the behavior of the current editing component to display raw text when the client hovers over the text.
 	 * <p>Tooltips do not inherit display characteristics, such as color and styles, from the message component on which they are applied.</p>
+	 *
 	 * @param lines The lines of text which will be displayed to the client upon hovering. The iteration order of this object will be the order in which the lines of the tooltip are created.
 	 * @return This builder instance.
 	 */
@@ -388,14 +407,15 @@ public class FancyMessage implements JsonRepresentedObject, Cloneable, Iterable<
 	/**
 	 * Set the behavior of the current editing component to display raw text when the client hovers over the text.
 	 * <p>Tooltips do not inherit display characteristics, such as color and styles, from the message component on which they are applied.</p>
+	 *
 	 * @param lines The lines of text which will be displayed to the client upon hovering.
 	 * @return This builder instance.
 	 */
 	public FancyMessage tooltip(final String... lines) {
 		StringBuilder builder = new StringBuilder();
-		for(int i = 0; i < lines.length; i++){
+		for (int i = 0; i < lines.length; i++) {
 			builder.append(lines[i]);
-			if(i != lines.length - 1){
+			if (i != lines.length - 1) {
 				builder.append('\n');
 			}
 		}
@@ -406,14 +426,15 @@ public class FancyMessage implements JsonRepresentedObject, Cloneable, Iterable<
 	/**
 	 * Set the behavior of the current editing component to display formatted text when the client hovers over the text.
 	 * <p>Tooltips do not inherit display characteristics, such as color and styles, from the message component on which they are applied.</p>
+	 *
 	 * @param text The formatted text which will be displayed to the client upon hovering.
 	 * @return This builder instance.
 	 */
-	public FancyMessage formattedTooltip(FancyMessage text){
-		for(MessagePart component : text.messageParts){
-			if(component.clickActionData != null && component.clickActionName != null){
+	public FancyMessage formattedTooltip(FancyMessage text) {
+		for (MessagePart component : text.messageParts) {
+			if (component.clickActionData != null && component.clickActionName != null) {
 				throw new IllegalArgumentException("The tooltip text cannot have click data.");
-			}else if(component.hoverActionData != null && component.hoverActionName != null){
+			} else if (component.hoverActionData != null && component.hoverActionName != null) {
 				throw new IllegalArgumentException("The tooltip text cannot have a tooltip.");
 			}
 		}
@@ -424,11 +445,12 @@ public class FancyMessage implements JsonRepresentedObject, Cloneable, Iterable<
 	/**
 	 * Set the behavior of the current editing component to display the specified lines of formatted text when the client hovers over the text.
 	 * <p>Tooltips do not inherit display characteristics, such as color and styles, from the message component on which they are applied.</p>
+	 *
 	 * @param lines The lines of formatted text which will be displayed to the client upon hovering.
 	 * @return This builder instance.
 	 */
-	public FancyMessage formattedTooltip(FancyMessage... lines){
-		if(lines.length < 1){
+	public FancyMessage formattedTooltip(FancyMessage... lines) {
+		if (lines.length < 1) {
 			onHover(null, null); // Clear tooltip
 			return this;
 		}
@@ -436,54 +458,56 @@ public class FancyMessage implements JsonRepresentedObject, Cloneable, Iterable<
 		FancyMessage result = new FancyMessage();
 		result.messageParts.clear(); // Remove the one existing text component that exists by default, which destabilizes the object
 
-		for(int i = 0; i < lines.length; i++){
-			try{
-				for(MessagePart component : lines[i]){
-					if(component.clickActionData != null && component.clickActionName != null){
+		for (int i = 0; i < lines.length; i++) {
+			try {
+				for (MessagePart component : lines[i]) {
+					if (component.clickActionData != null && component.clickActionName != null) {
 						throw new IllegalArgumentException("The tooltip text cannot have click data.");
-					}else if(component.hoverActionData != null && component.hoverActionName != null){
+					} else if (component.hoverActionData != null && component.hoverActionName != null) {
 						throw new IllegalArgumentException("The tooltip text cannot have a tooltip.");
 					}
-					if(component.hasText()){
+					if (component.hasText()) {
 						result.messageParts.add(component.clone());
 					}
 				}
-				if(i != lines.length - 1){
+				if (i != lines.length - 1) {
 					result.messageParts.add(new MessagePart(rawText("\n")));
 				}
 			} catch (CloneNotSupportedException e) {
 				Bukkit.getLogger().log(Level.WARNING, "Failed to clone object", e);
 				return this;
 			}
-		} 
+		}
 		return formattedTooltip(result.messageParts.isEmpty() ? null : result); // Throws NPE if size is 0, intended
 	}
 
 	/**
 	 * Set the behavior of the current editing component to display the specified lines of formatted text when the client hovers over the text.
 	 * <p>Tooltips do not inherit display characteristics, such as color and styles, from the message component on which they are applied.</p>
+	 *
 	 * @param lines The lines of text which will be displayed to the client upon hovering. The iteration order of this object will be the order in which the lines of the tooltip are created.
 	 * @return This builder instance.
 	 */
-	public FancyMessage formattedTooltip(final Iterable<FancyMessage> lines){
+	public FancyMessage formattedTooltip(final Iterable<FancyMessage> lines) {
 		return formattedTooltip(ArrayWrapper.toArray(lines, FancyMessage.class));
 	}
 
 	/**
 	 * If the text is a translatable key, and it has replaceable values, this function can be used to set the replacements that will be used in the message.
+	 *
 	 * @param replacements The replacements, in order, that will be used in the language-specific message.
 	 * @return This builder instance.
 	 */
-	public FancyMessage translationReplacements(final String... replacements){
-		for(String str : replacements){
+	public FancyMessage translationReplacements(final String... replacements) {
+		for (String str : replacements) {
 			latest().translationReplacements.add(new JsonString(str));
 		}
 		dirty = true;
-		
+
 		return this;
 	}
 	/*
-	
+
 	/**
 	 * If the text is a translatable key, and it has replaceable values, this function can be used to set the replacements that will be used in the message.
 	 * @param replacements The replacements, in order, that will be used in the language-specific message.
@@ -493,39 +517,42 @@ public class FancyMessage implements JsonRepresentedObject, Cloneable, Iterable<
 		for(CharSequence str : replacements){
 			latest().translationReplacements.add(new JsonString(str));
 		}
-		
+
 		return this;
 	}
-	
+
 	*/
-	
+
 	/**
 	 * If the text is a translatable key, and it has replaceable values, this function can be used to set the replacements that will be used in the message.
+	 *
 	 * @param replacements The replacements, in order, that will be used in the language-specific message.
 	 * @return This builder instance.
 	 */
-	public FancyMessage translationReplacements(final FancyMessage... replacements){
-		for(FancyMessage str : replacements){
+	public FancyMessage translationReplacements(final FancyMessage... replacements) {
+		for (FancyMessage str : replacements) {
 			latest().translationReplacements.add(str);
 		}
-		
+
 		dirty = true;
-		
+
 		return this;
 	}
-	
+
 	/**
 	 * If the text is a translatable key, and it has replaceable values, this function can be used to set the replacements that will be used in the message.
+	 *
 	 * @param replacements The replacements, in order, that will be used in the language-specific message.
 	 * @return This builder instance.
 	 */
-	public FancyMessage translationReplacements(final Iterable<FancyMessage> replacements){		
+	public FancyMessage translationReplacements(final Iterable<FancyMessage> replacements) {
 		return translationReplacements(ArrayWrapper.toArray(replacements, FancyMessage.class));
 	}
-	
+
 	/**
 	 * Terminate construction of the current editing component, and begin construction of a new message component.
 	 * After a successful call to this method, all setter methods will refer to a new message component, created as a result of the call to this method.
+	 *
 	 * @param text The text which will populate the new message component.
 	 * @return This builder instance.
 	 */
@@ -536,6 +563,7 @@ public class FancyMessage implements JsonRepresentedObject, Cloneable, Iterable<
 	/**
 	 * Terminate construction of the current editing component, and begin construction of a new message component.
 	 * After a successful call to this method, all setter methods will refer to a new message component, created as a result of the call to this method.
+	 *
 	 * @param text The text which will populate the new message component.
 	 * @return This builder instance.
 	 */
@@ -551,6 +579,7 @@ public class FancyMessage implements JsonRepresentedObject, Cloneable, Iterable<
 	/**
 	 * Terminate construction of the current editing component, and begin construction of a new message component.
 	 * After a successful call to this method, all setter methods will refer to a new message component, created as a result of the call to this method.
+	 *
 	 * @return This builder instance.
 	 */
 	public FancyMessage then() {
@@ -563,7 +592,7 @@ public class FancyMessage implements JsonRepresentedObject, Cloneable, Iterable<
 	}
 
 	@Override
-	public void writeJson(JsonWriter writer) throws IOException{
+	public void writeJson(JsonWriter writer) throws IOException {
 		if (messageParts.size() == 1) {
 			latest().writeJson(writer);
 		} else {
@@ -578,6 +607,7 @@ public class FancyMessage implements JsonRepresentedObject, Cloneable, Iterable<
 	/**
 	 * Serialize this fancy message, converting it into syntactically-valid JSON using a {@link JsonWriter}.
 	 * This JSON should be compatible with vanilla formatter commands such as {@code /tellraw}.
+	 *
 	 * @return The JSON string representing this object.
 	 */
 	public String toJSONString() {
@@ -599,43 +629,44 @@ public class FancyMessage implements JsonRepresentedObject, Cloneable, Iterable<
 
 	/**
 	 * Sends this message to a player. The player will receive the fully-fledged formatted display of this message.
+	 *
 	 * @param player The player who will receive the message.
 	 */
-	public void send(Player player){
+	public void send(Player player) {
 		send(player, toJSONString());
 	}
-        
-        private void send(CommandSender sender, String jsonString){
-                if (!(sender instanceof Player)){
-                        sender.sendMessage(toOldMessageFormat());
-                        return;
-                }
-                Player player = (Player) sender;
-                try {
+
+	private void send(CommandSender sender, String jsonString) {
+		if (!(sender instanceof Player)) {
+			sender.sendMessage(toOldMessageFormat());
+			return;
+		}
+		Player player = (Player) sender;
+		try {
 			Object handle = Reflection.getHandle(player);
 			Object connection = Reflection.getField(handle.getClass(), "playerConnection").get(handle);
 			Reflection.getMethod(connection.getClass(), "sendPacket", Reflection.getNMSClass("Packet")).invoke(connection, createChatPacket(jsonString));
 		} catch (IllegalArgumentException e) {
-                        Bukkit.getLogger().log(Level.WARNING, "Argument could not be passed.", e);
+			Bukkit.getLogger().log(Level.WARNING, "Argument could not be passed.", e);
 		} catch (IllegalAccessException e) {
-                        Bukkit.getLogger().log(Level.WARNING, "Could not access method.", e);
-                } catch (InstantiationException e) {
-                        Bukkit.getLogger().log(Level.WARNING, "Underlying class is abstract.", e);
-                } catch (InvocationTargetException e) {
-                        Bukkit.getLogger().log(Level.WARNING, "A error has occured durring invoking of method.", e);
-                } catch (NoSuchMethodException e) {
-                        Bukkit.getLogger().log(Level.WARNING, "Could not find method.", e);
-                } catch (ClassNotFoundException e) {
-                        Bukkit.getLogger().log(Level.WARNING, "Could not find class.", e);
-                }
-        }
+			Bukkit.getLogger().log(Level.WARNING, "Could not access method.", e);
+		} catch (InstantiationException e) {
+			Bukkit.getLogger().log(Level.WARNING, "Underlying class is abstract.", e);
+		} catch (InvocationTargetException e) {
+			Bukkit.getLogger().log(Level.WARNING, "A error has occured durring invoking of method.", e);
+		} catch (NoSuchMethodException e) {
+			Bukkit.getLogger().log(Level.WARNING, "Could not find method.", e);
+		} catch (ClassNotFoundException e) {
+			Bukkit.getLogger().log(Level.WARNING, "Could not find class.", e);
+		}
+	}
 
 	// The ChatSerializer's instance of Gson
 	private static Object nmsChatSerializerGsonInstance;
 	private static Method fromJsonMethod;
 
 	private Object createChatPacket(String json) throws IllegalArgumentException, IllegalAccessException, InstantiationException, InvocationTargetException, NoSuchMethodException, ClassNotFoundException {
-		if(nmsChatSerializerGsonInstance == null){
+		if (nmsChatSerializerGsonInstance == null) {
 			// Find the field and its value, completely bypassing obfuscation
 			Class<?> chatSerializerClazz;
 
@@ -678,20 +709,22 @@ public class FancyMessage implements JsonRepresentedObject, Cloneable, Iterable<
 	 * Sends this message to a command sender.
 	 * If the sender is a player, they will receive the fully-fledged formatted display of this message.
 	 * Otherwise, they will receive a version of this message with less formatting.
+	 *
 	 * @param sender The command sender who will receive the message.
 	 * @see #toOldMessageFormat()
 	 */
 	public void send(CommandSender sender) {
-                send(sender, toJSONString());
+		send(sender, toJSONString());
 	}
 
 	/**
 	 * Sends this message to multiple command senders.
+	 *
 	 * @param senders The command senders who will receive the message.
 	 * @see #send(CommandSender)
 	 */
 	public void send(final Iterable<? extends CommandSender> senders) {
-                String string = toJSONString();
+		String string = toJSONString();
 		for (final CommandSender sender : senders) {
 			send(sender, string);
 		}
@@ -711,13 +744,14 @@ public class FancyMessage implements JsonRepresentedObject, Cloneable, Iterable<
 	 * </p>
 	 * <p>
 	 * Color and formatting can be removed from the returned string by using {@link ChatColor#stripColor(String)}.</p>
+	 *
 	 * @return A human-readable string representing limited formatting in addition to the core text of this message.
 	 */
 	public String toOldMessageFormat() {
 		StringBuilder result = new StringBuilder();
 		for (MessagePart part : this) {
 			result.append(part.color == null ? "" : part.color);
-			for(ChatColor formatSpecifier : part.styles){
+			for (ChatColor formatSpecifier : part.styles) {
 				result.append(formatSpecifier);
 			}
 			result.append(part.text);
@@ -755,12 +789,13 @@ public class FancyMessage implements JsonRepresentedObject, Cloneable, Iterable<
 	 * Deserializes a JSON-represented message from a mapping of key-value pairs.
 	 * This is called by the Bukkit serialization API.
 	 * It is not intended for direct public API consumption.
+	 *
 	 * @param serialized The key-value mapping which represents a fancy message.
 	 */
 	@SuppressWarnings("unchecked")
-	public static FancyMessage deserialize(Map<String, Object> serialized){
+	public static FancyMessage deserialize(Map<String, Object> serialized) {
 		FancyMessage msg = new FancyMessage();
-		msg.messageParts = (List<MessagePart>)serialized.get("messageParts");
+		msg.messageParts = (List<MessagePart>) serialized.get("messageParts");
 		msg.jsonString = serialized.containsKey("JSON") ? serialized.get("JSON").toString() : null;
 		msg.dirty = !serialized.containsKey("JSON");
 		return msg;
@@ -772,68 +807,69 @@ public class FancyMessage implements JsonRepresentedObject, Cloneable, Iterable<
 	public Iterator<MessagePart> iterator() {
 		return messageParts.iterator();
 	}
-	
+
 	private static JsonParser _stringParser = new JsonParser();
-	
+
 	/**
 	 * Deserializes a fancy message from its JSON representation. This JSON representation is of the format of
 	 * that returned by {@link #toJSONString()}, and is compatible with vanilla inputs.
+	 *
 	 * @param json The JSON string which represents a fancy message.
 	 * @return A {@code FancyMessage} representing the parameterized JSON message.
 	 */
-	public static FancyMessage deserialize(String json){
+	public static FancyMessage deserialize(String json) {
 		JsonObject serialized = _stringParser.parse(json).getAsJsonObject();
 		JsonArray extra = serialized.getAsJsonArray("extra"); // Get the extra component
 		FancyMessage returnVal = new FancyMessage();
 		returnVal.messageParts.clear();
-		for(JsonElement mPrt : extra){
+		for (JsonElement mPrt : extra) {
 			MessagePart component = new MessagePart();
 			JsonObject messagePart = mPrt.getAsJsonObject();
-			for(Map.Entry<String, JsonElement> entry : messagePart.entrySet()){
+			for (Map.Entry<String, JsonElement> entry : messagePart.entrySet()) {
 				// Deserialize text
-				if(TextualComponent.isTextKey(entry.getKey())){
+				if (TextualComponent.isTextKey(entry.getKey())) {
 					// The map mimics the YAML serialization, which has a "key" field and one or more "value" fields
 					Map<String, Object> serializedMapForm = new HashMap<String, Object>(); // Must be object due to Bukkit serializer API compliance
 					serializedMapForm.put("key", entry.getKey());
-					if(entry.getValue().isJsonPrimitive()){
+					if (entry.getValue().isJsonPrimitive()) {
 						// Assume string
 						serializedMapForm.put("value", entry.getValue().getAsString());
-					}else{
+					} else {
 						// Composite object, but we assume each element is a string
-						for(Map.Entry<String, JsonElement> compositeNestedElement : entry.getValue().getAsJsonObject().entrySet()){
+						for (Map.Entry<String, JsonElement> compositeNestedElement : entry.getValue().getAsJsonObject().entrySet()) {
 							serializedMapForm.put("value." + compositeNestedElement.getKey(), compositeNestedElement.getValue().getAsString());
 						}
 					}
 					component.text = TextualComponent.deserialize(serializedMapForm);
-				}else if(MessagePart.stylesToNames.inverse().containsKey(entry.getKey())){
-					if(entry.getValue().getAsBoolean()){
+				} else if (MessagePart.stylesToNames.inverse().containsKey(entry.getKey())) {
+					if (entry.getValue().getAsBoolean()) {
 						component.styles.add(MessagePart.stylesToNames.inverse().get(entry.getKey()));
 					}
-				}else if(entry.getKey().equals("color")){
+				} else if (entry.getKey().equals("color")) {
 					component.color = ChatColor.valueOf(entry.getValue().getAsString().toUpperCase());
-				}else if(entry.getKey().equals("clickEvent")){
+				} else if (entry.getKey().equals("clickEvent")) {
 					JsonObject object = entry.getValue().getAsJsonObject();
 					component.clickActionName = object.get("action").getAsString();
 					component.clickActionData = object.get("value").getAsString();
-				}else if(entry.getKey().equals("hoverEvent")){
+				} else if (entry.getKey().equals("hoverEvent")) {
 					JsonObject object = entry.getValue().getAsJsonObject();
 					component.hoverActionName = object.get("action").getAsString();
-					if(object.get("value").isJsonPrimitive()){
+					if (object.get("value").isJsonPrimitive()) {
 						// Assume string
 						component.hoverActionData = new JsonString(object.get("value").getAsString());
-					}else{
+					} else {
 						// Assume composite type
 						// The only composite type we currently store is another FancyMessage
 						// Therefore, recursion time!
 						component.hoverActionData = deserialize(object.get("value").toString() /* This should properly serialize the JSON object as a JSON string */);
 					}
-				}else if(entry.getKey().equals("insertion")){
+				} else if (entry.getKey().equals("insertion")) {
 					component.insertionData = entry.getValue().getAsString();
-				}else if(entry.getKey().equals("with")){
-					for(JsonElement object : entry.getValue().getAsJsonArray()){
-						if(object.isJsonPrimitive()){
+				} else if (entry.getKey().equals("with")) {
+					for (JsonElement object : entry.getValue().getAsJsonArray()) {
+						if (object.isJsonPrimitive()) {
 							component.translationReplacements.add(new JsonString(object.getAsString()));
-						}else{
+						} else {
 							// Only composite type stored in this array is - again - FancyMessages
 							// Recurse within this function to parse this as a translation replacement
 							component.translationReplacements.add(deserialize(object.toString()));
@@ -845,4 +881,5 @@ public class FancyMessage implements JsonRepresentedObject, Cloneable, Iterable<
 		}
 		return returnVal;
 	}
+
 }

--- a/src/main/java/mkremins/fanciful/FancyMessage.java
+++ b/src/main/java/mkremins/fanciful/FancyMessage.java
@@ -670,14 +670,18 @@ public class FancyMessage implements JsonRepresentedObject, Cloneable, Iterable<
 			// Find the field and its value, completely bypassing obfuscation
 			Class<?> chatSerializerClazz;
 
-			String version = Reflection.getVersion();
-			double majorVersion = Double.parseDouble(version.replace('_', '.').substring(1, 4));
-			int lesserVersion = 0;
-			if (majorVersion == 1.8) {
-				lesserVersion = Integer.parseInt(version.substring(6, 7));
-			}
+			// Get the three parts of the version string (major version is currently unused)
+			// vX_Y_RZ
+			//   X = major
+			//   Y = minor
+			//   Z = revision
+			final String version = Reflection.getVersion();
+			String[] split = version.substring(1, version.length() - 1).split("_"); // Remove trailing dot
+			//int majorVersion = Integer.parseInt(split[0]);
+			int minorVersion = Integer.parseInt(split[1]);
+			int revisionVersion = Integer.parseInt(split[2].substring(1)); // Substring to ignore R
 
-			if (majorVersion < 1.8 || (majorVersion == 1.8 && lesserVersion == 1)) {
+			if (minorVersion < 8 || (minorVersion == 8 && revisionVersion == 1)) {
 				chatSerializerClazz = Reflection.getNMSClass("ChatSerializer");
 			} else {
 				chatSerializerClazz = Reflection.getNMSClass("IChatBaseComponent$ChatSerializer");

--- a/src/main/java/mkremins/fanciful/JsonString.java
+++ b/src/main/java/mkremins/fanciful/JsonString.java
@@ -15,8 +15,8 @@ import org.bukkit.configuration.serialization.ConfigurationSerializable;
 final class JsonString implements JsonRepresentedObject, ConfigurationSerializable {
 
 	private String _value;
-	
-	public JsonString(CharSequence value){
+
+	public JsonString(CharSequence value) {
 		_value = value == null ? null : value.toString();
 	}
 
@@ -24,8 +24,8 @@ final class JsonString implements JsonRepresentedObject, ConfigurationSerializab
 	public void writeJson(JsonWriter writer) throws IOException {
 		writer.value(getValue());
 	}
-	
-	public String getValue(){
+
+	public String getValue() {
 		return _value;
 	}
 
@@ -34,13 +34,14 @@ final class JsonString implements JsonRepresentedObject, ConfigurationSerializab
 		theSingleValue.put("stringValue", _value);
 		return theSingleValue;
 	}
-	
-	public static JsonString deserialize(Map<String, Object> map){
+
+	public static JsonString deserialize(Map<String, Object> map) {
 		return new JsonString(map.get("stringValue").toString());
 	}
-	
+
 	@Override
-	public String toString(){
+	public String toString() {
 		return _value;
 	}
+
 }

--- a/src/main/java/mkremins/fanciful/MessagePart.java
+++ b/src/main/java/mkremins/fanciful/MessagePart.java
@@ -1,19 +1,18 @@
 package mkremins.fanciful;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
-
+import com.google.common.collect.BiMap;
+import com.google.common.collect.ImmutableBiMap;
 import com.google.gson.stream.JsonWriter;
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.configuration.serialization.ConfigurationSerializable;
 import org.bukkit.configuration.serialization.ConfigurationSerialization;
 
-import com.google.common.collect.BiMap;
-import com.google.common.collect.ImmutableBiMap;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.logging.Level;
-import org.bukkit.Bukkit;
 
 /**
  * Internal class: Represents a component of a JSON-serializable {@link FancyMessage}.
@@ -22,14 +21,13 @@ final class MessagePart implements JsonRepresentedObject, ConfigurationSerializa
 
 	ChatColor color = ChatColor.WHITE;
 	ArrayList<ChatColor> styles = new ArrayList<ChatColor>();
-	String clickActionName = null, clickActionData = null,
-			hoverActionName = null;
+	String clickActionName = null, clickActionData = null, hoverActionName = null;
 	JsonRepresentedObject hoverActionData = null;
 	TextualComponent text = null;
 	String insertionData = null;
 	ArrayList<JsonRepresentedObject> translationReplacements = new ArrayList<JsonRepresentedObject>();
 
-	MessagePart(final TextualComponent text){
+	MessagePart(final TextualComponent text) {
 		this.text = text;
 	}
 
@@ -41,40 +39,43 @@ final class MessagePart implements JsonRepresentedObject, ConfigurationSerializa
 		return text != null;
 	}
 
-        @Override
+	@Override
 	@SuppressWarnings("unchecked")
-	public MessagePart clone() throws CloneNotSupportedException{
-		MessagePart obj = (MessagePart)super.clone();
-		obj.styles = (ArrayList<ChatColor>)styles.clone();
-		if(hoverActionData instanceof JsonString){
-			obj.hoverActionData = new JsonString(((JsonString)hoverActionData).getValue());
-		}else if(hoverActionData instanceof FancyMessage){
-			obj.hoverActionData = ((FancyMessage)hoverActionData).clone();
+	public MessagePart clone() throws CloneNotSupportedException {
+		MessagePart obj = (MessagePart) super.clone();
+		obj.styles = (ArrayList<ChatColor>) styles.clone();
+		if (hoverActionData instanceof JsonString) {
+			obj.hoverActionData = new JsonString(((JsonString) hoverActionData).getValue());
+		} else if (hoverActionData instanceof FancyMessage) {
+			obj.hoverActionData = ((FancyMessage) hoverActionData).clone();
 		}
-		obj.translationReplacements = (ArrayList<JsonRepresentedObject>)translationReplacements.clone();
+		obj.translationReplacements = (ArrayList<JsonRepresentedObject>) translationReplacements.clone();
 		return obj;
 
 	}
 
 	static final BiMap<ChatColor, String> stylesToNames;
 
-	static{
+	static {
 		ImmutableBiMap.Builder<ChatColor, String> builder = ImmutableBiMap.builder();
-		for (final ChatColor style : ChatColor.values()){
-			if(!style.isFormat()){
+		for (final ChatColor style : ChatColor.values()) {
+			if (!style.isFormat()) {
 				continue;
 			}
 
 			String styleName;
 			switch (style) {
-			case MAGIC:
-				styleName = "obfuscated"; break;
-			case UNDERLINE:
-				styleName = "underlined"; break;
-			default:
-				styleName = style.name().toLowerCase(); break;
+				case MAGIC:
+					styleName = "obfuscated";
+					break;
+				case UNDERLINE:
+					styleName = "underlined";
+					break;
+				default:
+					styleName = style.name().toLowerCase();
+					break;
 			}
-			
+
 			builder.put(style, styleName);
 		}
 		stylesToNames = builder.build();
@@ -90,31 +91,31 @@ final class MessagePart implements JsonRepresentedObject, ConfigurationSerializa
 			}
 			if (clickActionName != null && clickActionData != null) {
 				json.name("clickEvent")
-				.beginObject()
-				.name("action").value(clickActionName)
-				.name("value").value(clickActionData)
-				.endObject();
+						.beginObject()
+						.name("action").value(clickActionName)
+						.name("value").value(clickActionData)
+						.endObject();
 			}
 			if (hoverActionName != null && hoverActionData != null) {
 				json.name("hoverEvent")
-				.beginObject()
-				.name("action").value(hoverActionName)
-				.name("value");
+						.beginObject()
+						.name("action").value(hoverActionName)
+						.name("value");
 				hoverActionData.writeJson(json);
 				json.endObject();
 			}
-			if(insertionData != null){
+			if (insertionData != null) {
 				json.name("insertion").value(insertionData);
 			}
-			if(translationReplacements.size() > 0 && text != null && TextualComponent.isTranslatableText(text)){
+			if (translationReplacements.size() > 0 && text != null && TextualComponent.isTranslatableText(text)) {
 				json.name("with").beginArray();
-				for(JsonRepresentedObject obj : translationReplacements){
+				for (JsonRepresentedObject obj : translationReplacements) {
 					obj.writeJson(json);
 				}
 				json.endArray();
 			}
 			json.endObject();
-		} catch(IOException e){
+		} catch (IOException e) {
 			Bukkit.getLogger().log(Level.WARNING, "A problem occured during writing of JSON string", e);
 		}
 	}
@@ -134,20 +135,20 @@ final class MessagePart implements JsonRepresentedObject, ConfigurationSerializa
 	}
 
 	@SuppressWarnings("unchecked")
-	public static MessagePart deserialize(Map<String, Object> serialized){
-		MessagePart part = new MessagePart((TextualComponent)serialized.get("text"));
-		part.styles = (ArrayList<ChatColor>)serialized.get("styles");
+	public static MessagePart deserialize(Map<String, Object> serialized) {
+		MessagePart part = new MessagePart((TextualComponent) serialized.get("text"));
+		part.styles = (ArrayList<ChatColor>) serialized.get("styles");
 		part.color = ChatColor.getByChar(serialized.get("color").toString());
-		part.hoverActionName = (String)serialized.get("hoverActionName");
-		part.hoverActionData = (JsonRepresentedObject)serialized.get("hoverActionData");
-		part.clickActionName = (String)serialized.get("clickActionName");
-		part.clickActionData = (String)serialized.get("clickActionData");
-		part.insertionData = (String)serialized.get("insertion");
-		part.translationReplacements = (ArrayList<JsonRepresentedObject>)serialized.get("translationReplacements");
+		part.hoverActionName = (String) serialized.get("hoverActionName");
+		part.hoverActionData = (JsonRepresentedObject) serialized.get("hoverActionData");
+		part.clickActionName = (String) serialized.get("clickActionName");
+		part.clickActionData = (String) serialized.get("clickActionData");
+		part.insertionData = (String) serialized.get("insertion");
+		part.translationReplacements = (ArrayList<JsonRepresentedObject>) serialized.get("translationReplacements");
 		return part;
 	}
 
-	static{
+	static {
 		ConfigurationSerialization.registerClass(MessagePart.class);
 	}
 

--- a/src/main/java/mkremins/fanciful/TextualComponent.java
+++ b/src/main/java/mkremins/fanciful/TextualComponent.java
@@ -1,15 +1,14 @@
 package mkremins.fanciful;
 
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import com.google.gson.stream.JsonWriter;
 import org.bukkit.configuration.serialization.ConfigurationSerializable;
 import org.bukkit.configuration.serialization.ConfigurationSerialization;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableMap;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Represents a textual component of a message part.
@@ -19,72 +18,73 @@ import com.google.common.collect.ImmutableMap;
  */
 public abstract class TextualComponent implements Cloneable {
 
-	static{
+	static {
 		ConfigurationSerialization.registerClass(TextualComponent.ArbitraryTextTypeComponent.class);
 		ConfigurationSerialization.registerClass(TextualComponent.ComplexTextTypeComponent.class);
 	}
-	
+
 	@Override
 	public String toString() {
 		return getReadableString();
 	}
-	
+
 	/**
-         * @return The JSON key used to represent text components of this type.
+	 * @return The JSON key used to represent text components of this type.
 	 */
 	public abstract String getKey();
-	
-        /**
-         * @return A readable String
+
+	/**
+	 * @return A readable String
 	 */
 	public abstract String getReadableString();
-        
+
 	/**
 	 * Clones a textual component instance.
 	 * The returned object should not reference this textual component instance, but should maintain the same key and value.
 	 */
 	@Override
 	public abstract TextualComponent clone() throws CloneNotSupportedException;
-	
+
 	/**
 	 * Writes the text data represented by this textual component to the specified JSON writer object.
 	 * A new object within the writer is not started.
+	 *
 	 * @param writer The object to which to write the JSON data.
 	 * @throws IOException If an error occurs while writing to the stream.
 	 */
 	public abstract void writeJson(JsonWriter writer) throws IOException;
-	
-	static TextualComponent deserialize(Map<String, Object> map){
-		if(map.containsKey("key") && map.size() == 2 && map.containsKey("value")){
+
+	static TextualComponent deserialize(Map<String, Object> map) {
+		if (map.containsKey("key") && map.size() == 2 && map.containsKey("value")) {
 			// Arbitrary text component
 			return ArbitraryTextTypeComponent.deserialize(map);
-		}else if(map.size() >= 2 && map.containsKey("key") && !map.containsKey("value") /* It contains keys that START WITH value */){
+		} else if (map.size() >= 2 && map.containsKey("key") && !map.containsKey("value") /* It contains keys that START WITH value */) {
 			// Complex JSON object
 			return ComplexTextTypeComponent.deserialize(map);
 		}
-		
+
 		return null;
 	}
-	
-	static boolean isTextKey(String key){
+
+	static boolean isTextKey(String key) {
 		return key.equals("translate") || key.equals("text") || key.equals("score") || key.equals("selector");
 	}
-	
-	static boolean isTranslatableText(TextualComponent component){
-		return component instanceof ComplexTextTypeComponent && ((ComplexTextTypeComponent)component).getKey().equals("translate");
+
+	static boolean isTranslatableText(TextualComponent component) {
+		return component instanceof ComplexTextTypeComponent && ((ComplexTextTypeComponent) component).getKey().equals("translate");
 	}
-	
+
 	/**
 	 * Internal class used to represent all types of text components.
 	 * Exception validating done is on keys and values.
 	 */
 	private static final class ArbitraryTextTypeComponent extends TextualComponent implements ConfigurationSerializable {
 
-		public ArbitraryTextTypeComponent(String key, String value){
+		public ArbitraryTextTypeComponent(String key, String value) {
 			setKey(key);
 			setValue(value);
 		}
-		
+
 		@Override
 		public String getKey() {
 			return _key;
@@ -94,7 +94,7 @@ public abstract class TextualComponent implements Cloneable {
 			Preconditions.checkArgument(key != null && !key.isEmpty(), "The key must be specified.");
 			_key = key;
 		}
-		
+
 		public String getValue() {
 			return _value;
 		}
@@ -106,7 +106,7 @@ public abstract class TextualComponent implements Cloneable {
 
 		private String _key;
 		private String _value;
-		
+
 		@Override
 		public TextualComponent clone() throws CloneNotSupportedException {
 			// Since this is a private and final class, we can just reinstantiate this class instead of casting super.clone
@@ -120,33 +120,33 @@ public abstract class TextualComponent implements Cloneable {
 
 		@SuppressWarnings("serial")
 		public Map<String, Object> serialize() {
-			return new HashMap<String, Object>(){{
+			return new HashMap<String, Object>() {{
 				put("key", getKey());
 				put("value", getValue());
 			}};
 		}
-		
-		public static ArbitraryTextTypeComponent deserialize(Map<String, Object> map){
+
+		public static ArbitraryTextTypeComponent deserialize(Map<String, Object> map) {
 			return new ArbitraryTextTypeComponent(map.get("key").toString(), map.get("value").toString());
 		}
 
 		@Override
-        public String getReadableString() {
+		public String getReadableString() {
 			return getValue();
 		}
 	}
-	
+
 	/**
 	 * Internal class used to represent a text component with a nested JSON value.
 	 * Exception validating done is on keys and values.
 	 */
-	private static final class ComplexTextTypeComponent extends TextualComponent implements ConfigurationSerializable{
+	private static final class ComplexTextTypeComponent extends TextualComponent implements ConfigurationSerializable {
 
-		public ComplexTextTypeComponent(String key, Map<String, String> values){
+		public ComplexTextTypeComponent(String key, Map<String, String> values) {
 			setKey(key);
 			setValue(values);
 		}
-		
+
 		@Override
 		public String getKey() {
 			return _key;
@@ -156,7 +156,7 @@ public abstract class TextualComponent implements Cloneable {
 			Preconditions.checkArgument(key != null && !key.isEmpty(), "The key must be specified.");
 			_key = key;
 		}
-		
+
 		public Map<String, String> getValue() {
 			return _value;
 		}
@@ -168,7 +168,7 @@ public abstract class TextualComponent implements Cloneable {
 
 		private String _key;
 		private Map<String, String> _value;
-		
+
 		@Override
 		public TextualComponent clone() throws CloneNotSupportedException {
 			// Since this is a private and final class, we can just reinstantiate this class instead of casting super.clone
@@ -179,51 +179,52 @@ public abstract class TextualComponent implements Cloneable {
 		public void writeJson(JsonWriter writer) throws IOException {
 			writer.name(getKey());
 			writer.beginObject();
-			for(Map.Entry<String, String> jsonPair : _value.entrySet()){
+			for (Map.Entry<String, String> jsonPair : _value.entrySet()) {
 				writer.name(jsonPair.getKey()).value(jsonPair.getValue());
 			}
 			writer.endObject();
 		}
-		
+
 		@SuppressWarnings("serial")
 		public Map<String, Object> serialize() {
-			return new java.util.HashMap<String, Object>(){{
+			return new java.util.HashMap<String, Object>() {{
 				put("key", getKey());
-				for(Map.Entry<String, String> valEntry : getValue().entrySet()){
+				for (Map.Entry<String, String> valEntry : getValue().entrySet()) {
 					put("value." + valEntry.getKey(), valEntry.getValue());
 				}
 			}};
 		}
-		
-		public static ComplexTextTypeComponent deserialize(Map<String, Object> map){
+
+		public static ComplexTextTypeComponent deserialize(Map<String, Object> map) {
 			String key = null;
 			Map<String, String> value = new HashMap<String, String>();
-			for(Map.Entry<String, Object> valEntry : map.entrySet()){
-				if(valEntry.getKey().equals("key")){
+			for (Map.Entry<String, Object> valEntry : map.entrySet()) {
+				if (valEntry.getKey().equals("key")) {
 					key = (String) valEntry.getValue();
-				}else if(valEntry.getKey().startsWith("value.")){
+				} else if (valEntry.getKey().startsWith("value.")) {
 					value.put(((String) valEntry.getKey()).substring(6) /* Strips out the value prefix */, valEntry.getValue().toString());
 				}
 			}
 			return new ComplexTextTypeComponent(key, value);
 		}
-		
+
 		@Override
 		public String getReadableString() {
 			return getKey();
 		}
 	}
-	
+
 	/**
 	 * Create a textual component representing a string literal.
 	 * This is the default type of textual component when a single string literal is given to a method.
+	 *
 	 * @param textValue The text which will be represented.
 	 * @return The text component representing the specified literal text.
 	 */
-	public static TextualComponent rawText(String textValue){
+	public static TextualComponent rawText(String textValue) {
 		return new ArbitraryTextTypeComponent("text", textValue);
 	}
-	
+
 
 	/**
 	 * Create a textual component representing a localized string.
@@ -231,62 +232,66 @@ public abstract class TextualComponent implements Cloneable {
 	 * <p>
 	 * If the specified translation key is not present on the client resource pack, the translation key will be displayed as a string literal to the client.
 	 * </p>
+	 *
 	 * @param translateKey The string key which maps to localized text.
 	 * @return The text component representing the specified localized text.
 	 */
-	public static TextualComponent localizedText(String translateKey){
+	public static TextualComponent localizedText(String translateKey) {
 		return new ArbitraryTextTypeComponent("translate", translateKey);
 	}
-	
-	private static void throwUnsupportedSnapshot(){
+
+	private static void throwUnsupportedSnapshot() {
 		throw new UnsupportedOperationException("This feature is only supported in snapshot releases.");
 	}
-	
+
 	/**
 	 * Create a textual component representing a scoreboard value.
 	 * The client will see their own score for the specified objective as the text represented by this component.
 	 * <p>
 	 * <b>This method is currently guaranteed to throw an {@code UnsupportedOperationException} as it is only supported on snapshot clients.</b>
 	 * </p>
+	 *
 	 * @param scoreboardObjective The name of the objective for which to display the score.
 	 * @return The text component representing the specified scoreboard score (for the viewing player), or {@code null} if an error occurs during JSON serialization.
 	 */
-	public static TextualComponent objectiveScore(String scoreboardObjective){
+	public static TextualComponent objectiveScore(String scoreboardObjective) {
 		return objectiveScore("*", scoreboardObjective);
 	}
-	
+
 	/**
 	 * Create a textual component representing a scoreboard value.
 	 * The client will see the score of the specified player for the specified objective as the text represented by this component.
 	 * <p>
 	 * <b>This method is currently guaranteed to throw an {@code UnsupportedOperationException} as it is only supported on snapshot clients.</b>
 	 * </p>
-	 * @param playerName The name of the player whos score will be shown. If this string represents the single-character sequence "*", the viewing player's score will be displayed.
-	 * Standard minecraft selectors (@a, @p, etc) are <em>not</em> supported.
+	 *
+	 * @param playerName		  The name of the player whos score will be shown. If this string represents the single-character sequence "*", the viewing player's score will be displayed.
+	 *							Standard minecraft selectors (@a, @p, etc) are <em>not</em> supported.
 	 * @param scoreboardObjective The name of the objective for which to display the score.
 	 * @return The text component representing the specified scoreboard score for the specified player, or {@code null} if an error occurs during JSON serialization.
 	 */
-	public static TextualComponent objectiveScore(String playerName, String scoreboardObjective){
+	public static TextualComponent objectiveScore(String playerName, String scoreboardObjective) {
 		throwUnsupportedSnapshot(); // Remove this line when the feature is released to non-snapshot versions, in addition to updating ALL THE OVERLOADS documentation accordingly
-		
+
 		return new ComplexTextTypeComponent("score", ImmutableMap.<String, String>builder()
 				.put("name", playerName)
 				.put("objective", scoreboardObjective)
 				.build());
 	}
-	
+
 	/**
 	 * Create a textual component representing a player name, retrievable by using a standard minecraft selector.
 	 * The client will see the players or entities captured by the specified selector as the text represented by this component.
 	 * <p>
 	 * <b>This method is currently guaranteed to throw an {@code UnsupportedOperationException} as it is only supported on snapshot clients.</b>
 	 * </p>
+	 *
 	 * @param selector The minecraft player or entity selector which will capture the entities whose string representations will be displayed in the place of this text component.
 	 * @return The text component representing the name of the entities captured by the selector.
 	 */
-	public static TextualComponent selector(String selector){
+	public static TextualComponent selector(String selector) {
 		throwUnsupportedSnapshot(); // Remove this line when the feature is released to non-snapshot versions, in addition to updating ALL THE OVERLOADS documentation accordingly
-		
+
 		return new ArbitraryTextTypeComponent("selector", selector);
 	}
 }

--- a/src/main/java/net/amoebaman/util/ArrayWrapper.java
+++ b/src/main/java/net/amoebaman/util/ArrayWrapper.java
@@ -1,10 +1,10 @@
 package net.amoebaman.util;
 
+import org.apache.commons.lang.Validate;
+
 import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.Collection;
-
-import org.apache.commons.lang.Validate;
 
 /**
  * Represents a wrapper around an array class of an arbitrary reference type,
@@ -12,95 +12,100 @@ import org.apache.commons.lang.Validate;
  * <p>
  * This class is intended for use as a key to a map.
  * </p>
- * @author Glen Husman
+ *
  * @param <E> The type of elements in the array.
+ * @author Glen Husman
  * @see Arrays
  */
 public final class ArrayWrapper<E> {
 
 	/**
 	 * Creates an array wrapper with some elements.
+	 *
 	 * @param elements The elements of the array.
 	 */
-	public ArrayWrapper(E... elements){
+	public ArrayWrapper(E... elements) {
 		setArray(elements);
 	}
-	
+
 	private E[] _array;
-	
+
 	/**
 	 * Retrieves a reference to the wrapped array instance.
+	 *
 	 * @return The array wrapped by this instance.
 	 */
-	public E[] getArray(){
-		return _array;	
+	public E[] getArray() {
+		return _array;
 	}
-	
+
 	/**
 	 * Set this wrapper to wrap a new array instance.
+	 *
 	 * @param array The new wrapped array.
 	 */
-	public void setArray(E[] array){
+	public void setArray(E[] array) {
 		Validate.notNull(array, "The array must not be null.");
 		_array = array;
 	}
-	
+
 	/**
 	 * Determines if this object has a value equivalent to another object.
+	 *
 	 * @see Arrays#equals(Object[], Object[])
 	 */
 	@SuppressWarnings("rawtypes")
 	@Override
-	public boolean equals(Object other)
-    {
-        if (!(other instanceof ArrayWrapper))
-        {
-            return false;
-        }
-        return Arrays.equals(_array, ((ArrayWrapper)other)._array);
-    }
+	public boolean equals(Object other) {
+		if (!(other instanceof ArrayWrapper)) {
+			return false;
+		}
+		return Arrays.equals(_array, ((ArrayWrapper) other)._array);
+	}
 
 	/**
 	 * Gets the hash code represented by this objects value.
-	 * @see Arrays#hashCode(Object[])
+	 *
 	 * @return This object's hash code.
+	 * @see Arrays#hashCode(Object[])
 	 */
-    @Override
-    public int hashCode()
-    {
-        return Arrays.hashCode(_array);
-    }
-    
-    /**
-     * Converts an iterable element collection to an array of elements.
-     * The iteration order of the specified object will be used as the array element order.
-     * @param list The iterable of objects which will be converted to an array.
-     * @param c The type of the elements of the array.
-     * @return An array of elements in the specified iterable.
-     */
-     @SuppressWarnings("unchecked")
-    public static <T> T[] toArray(Iterable<? extends T> list, Class<T> c) {
-        int size = -1;
-        if(list instanceof Collection<?>){
-        	@SuppressWarnings("rawtypes")
-			Collection coll = (Collection)list;
-        	size = coll.size();
-        }
-        
-        
-        if(size < 0){
-        	size = 0;
-        	// Ugly hack: Count it ourselves
-        	for(@SuppressWarnings("unused") T element : list){
-        		size++;
-        	}
-        }
-    	
-        T[] result = (T[]) Array.newInstance(c, size);
-        int i = 0;
-        for(T element : list){ // Assumes iteration order is consistent
-    		result[i++] = element; // Assign array element at index THEN increment counter
-    	}
-        return result;
-    }
+	@Override
+	public int hashCode() {
+		return Arrays.hashCode(_array);
+	}
+
+	/**
+	 * Converts an iterable element collection to an array of elements.
+	 * The iteration order of the specified object will be used as the array element order.
+	 *
+	 * @param list The iterable of objects which will be converted to an array.
+	 * @param c	The type of the elements of the array.
+	 * @return An array of elements in the specified iterable.
+	 */
+	@SuppressWarnings("unchecked")
+	public static <T> T[] toArray(Iterable<? extends T> list, Class<T> c) {
+		int size = -1;
+		if (list instanceof Collection<?>) {
+			@SuppressWarnings("rawtypes")
+			Collection coll = (Collection) list;
+			size = coll.size();
+		}
+
+
+		if (size < 0) {
+			size = 0;
+			// Ugly hack: Count it ourselves
+			for (@SuppressWarnings("unused") T element : list) {
+				size++;
+			}
+		}
+
+		T[] result = (T[]) Array.newInstance(c, size);
+		int i = 0;
+		for (T element : list) { // Assumes iteration order is consistent
+			result[i++] = element; // Assign array element at index THEN increment counter
+		}
+		return result;
+	}
+
 }

--- a/src/main/java/net/amoebaman/util/Reflection.java
+++ b/src/main/java/net/amoebaman/util/Reflection.java
@@ -1,12 +1,12 @@
 package net.amoebaman.util;
 
+import org.bukkit.Bukkit;
+
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-
-import org.bukkit.Bukkit;
 
 /**
  * A class containing static utility methods and caches which are intended as reflective conveniences.
@@ -15,26 +15,25 @@ import org.bukkit.Bukkit;
 public final class Reflection {
 
 	private static String _versionString;
-	
-	private Reflection(){
-		
-	}
-	
+
+	private Reflection() { }
+
 	/**
 	 * Gets the version string from the package name of the CraftBukkit server implementation.
 	 * This is needed to bypass the JAR package name changing on each update.
+	 *
 	 * @return The version string of the OBC and NMS packages, <em>including the trailing dot</em>.
 	 */
 	public synchronized static String getVersion() {
-		if(_versionString == null){
-			if(Bukkit.getServer() == null){
+		if (_versionString == null) {
+			if (Bukkit.getServer() == null) {
 				// The server hasn't started, static initializer call?
 				return null;
 			}
 			String name = Bukkit.getServer().getClass().getPackage().getName();
 			_versionString = name.substring(name.lastIndexOf('.') + 1) + ".";
 		}
-		
+
 		return _versionString;
 	}
 
@@ -42,22 +41,24 @@ public final class Reflection {
 	 * Stores loaded classes from the {@code net.minecraft.server} package.
 	 */
 	private static final Map<String, Class<?>> _loadedNMSClasses = new HashMap<String, Class<?>>();
+
 	/**
 	 * Stores loaded classes from the {@code org.bukkit.craftbukkit} package (and subpackages).
 	 */
 	private static final Map<String, Class<?>> _loadedOBCClasses = new HashMap<String, Class<?>>();
-	
+
 	/**
 	 * Gets a {@link Class} object representing a type contained within the {@code net.minecraft.server} versioned package.
 	 * The class instances returned by this method are cached, such that no lookup will be done twice (unless multiple threads are accessing this method simultaneously).
+	 *
 	 * @param className The name of the class, excluding the package, within NMS.
 	 * @return The class instance representing the specified NMS class, or {@code null} if it could not be loaded.
 	 */
 	public synchronized static Class<?> getNMSClass(String className) {
-		if(_loadedNMSClasses.containsKey(className)){
+		if (_loadedNMSClasses.containsKey(className)) {
 			return _loadedNMSClasses.get(className);
 		}
-		
+
 		String fullName = "net.minecraft.server." + getVersion() + className;
 		Class<?> clazz = null;
 		try {
@@ -74,14 +75,15 @@ public final class Reflection {
 	/**
 	 * Gets a {@link Class} object representing a type contained within the {@code org.bukkit.craftbukkit} versioned package.
 	 * The class instances returned by this method are cached, such that no lookup will be done twice (unless multiple threads are accessing this method simultaneously).
+	 *
 	 * @param className The name of the class, excluding the package, within OBC. This name may contain a subpackage name, such as {@code inventory.CraftItemStack}.
 	 * @return The class instance representing the specified OBC class, or {@code null} if it could not be loaded.
 	 */
 	public synchronized static Class<?> getOBCClass(String className) {
-		if(_loadedOBCClasses.containsKey(className)){
+		if (_loadedOBCClasses.containsKey(className)) {
 			return _loadedOBCClasses.get(className);
 		}
-		
+
 		String fullName = "org.bukkit.craftbukkit." + getVersion() + className;
 		Class<?> clazz = null;
 		try {
@@ -100,6 +102,7 @@ public final class Reflection {
 	 * <p>
 	 * The only match currently attempted by this method is a retrieval by using a parameterless {@code getHandle()} method implemented by the runtime type of the specified object.
 	 * </p>
+	 *
 	 * @param obj The object for which to retrieve an NMS handle.
 	 * @return The NMS handle of the specified object, or {@code null} if it could not be retrieved using {@code getHandle()}.
 	 */
@@ -113,7 +116,7 @@ public final class Reflection {
 	}
 
 	private static final Map<Class<?>, Map<String, Field>> _loadedFields = new HashMap<Class<?>, Map<String, Field>>();
-	
+
 	/**
 	 * Retrieves a {@link Field} instance declared by the specified class with the specified name.
 	 * Java access modifiers are ignored during this retrieval. No guarantee is made as to whether the field
@@ -126,20 +129,21 @@ public final class Reflection {
 	 * If a field is deemed suitable for return, {@link Field#setAccessible(boolean) setAccessible} will be invoked with an argument of {@code true} before it is returned.
 	 * This ensures that callers do not have to check or worry about Java access modifiers when dealing with the returned instance.
 	 * </p>
+	 *
 	 * @param clazz The class which contains the field to retrieve.
-	 * @param name The declared name of the field in the class.
+	 * @param name  The declared name of the field in the class.
 	 * @return A field object with the specified name declared by the specified class.
 	 * @see Class#getDeclaredField(String)
 	 */
 	public synchronized static Field getField(Class<?> clazz, String name) {
 		Map<String, Field> loaded;
-		if(!_loadedFields.containsKey(clazz)){
+		if (!_loadedFields.containsKey(clazz)) {
 			loaded = new HashMap<String, Field>();
 			_loadedFields.put(clazz, loaded);
-		}else{
+		} else {
 			loaded = _loadedFields.get(clazz);
 		}
-		if(loaded.containsKey(name)){
+		if (loaded.containsKey(name)) {
 			// If the field is loaded (or cached as not existing), return the relevant value, which might be null
 			return loaded.get(name);
 		}
@@ -162,7 +166,7 @@ public final class Reflection {
 	 * The map maps [types to maps of [method names to maps of [parameter types to method instances]]].
 	 */
 	private static final Map<Class<?>, Map<String, Map<ArrayWrapper<Class<?>>, Method>>> _loadedMethods = new HashMap<Class<?>, Map<String, Map<ArrayWrapper<Class<?>>, Method>>>();
-	
+
 	/**
 	 * Retrieves a {@link Method} instance declared by the specified class with the specified name and argument types.
 	 * Java access modifiers are ignored during this retrieval. No guarantee is made as to whether the field
@@ -178,34 +182,35 @@ public final class Reflection {
 	 * <p>
 	 * This method does <em>not</em> search superclasses of the specified type for methods with the specified signature.
 	 * Callers wishing this behavior should use {@link Class#getDeclaredMethod(String, Class...)}.
+	 *
 	 * @param clazz The class which contains the method to retrieve.
-	 * @param name The declared name of the method in the class.
-	 * @param args The formal argument types of the method.
+	 * @param name  The declared name of the method in the class.
+	 * @param args  The formal argument types of the method.
 	 * @return A method object with the specified name declared by the specified class.
 	 */
-	public synchronized static Method getMethod(Class<?> clazz, String name,
-			Class<?>... args) {
-		if(!_loadedMethods.containsKey(clazz)){
+	public synchronized static Method getMethod(Class<?> clazz, String name, Class<?>... args) {
+		if (!_loadedMethods.containsKey(clazz)) {
 			_loadedMethods.put(clazz, new HashMap<String, Map<ArrayWrapper<Class<?>>, Method>>());
 		}
-		
+
 		Map<String, Map<ArrayWrapper<Class<?>>, Method>> loadedMethodNames = _loadedMethods.get(clazz);
-		if(!loadedMethodNames.containsKey(name)){
+		if (!loadedMethodNames.containsKey(name)) {
 			loadedMethodNames.put(name, new HashMap<ArrayWrapper<Class<?>>, Method>());
 		}
-		
+
 		Map<ArrayWrapper<Class<?>>, Method> loadedSignatures = loadedMethodNames.get(name);
 		ArrayWrapper<Class<?>> wrappedArg = new ArrayWrapper<Class<?>>(args);
-		if(loadedSignatures.containsKey(wrappedArg)){
+		if (loadedSignatures.containsKey(wrappedArg)) {
 			return loadedSignatures.get(wrappedArg);
 		}
-		
-		for (Method m : clazz.getMethods())
-			if (m.getName().equals(name) && Arrays.equals(args, m.getParameterTypes())) {
-				m.setAccessible(true);
-				loadedSignatures.put(wrappedArg, m);
-				return m;
-			}
+
+		for (Method m : clazz.getMethods()) {
+  	  	  	if (m.getName().equals(name) && Arrays.equals(args, m.getParameterTypes())) {
+  	  	  	  	m.setAccessible(true);
+  	  	  	  	loadedSignatures.put(wrappedArg, m);
+  	  	  	  	return m;
+  	  	  	}
+  	  	}
 		loadedSignatures.put(wrappedArg, null);
 		return null;
 	}


### PR DESCRIPTION
This fixes the version parsing code expecting a single digit.

I also cleaned up a bunch of the code since there were inconsistencies with indents, among other things.

@mkremins I removed the build status image on the README since I do not host a CI server anymore.  It would be helpful if you set up Travis CI or an alternative for the project.  If you do, let me know and we can make it deploy to my repository automatically.  For now, I have deployed the version manually for people to use.